### PR TITLE
fix: Remove unnecessary safe library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
         "brainbits/phpcs-standard": "^7.0",
         "brainbits/phpstan-rules": "^3.0",
         "phpunit/phpunit": "^10.0",
-        "thecodingmachine/phpstan-safe-rule": "^1.0",
         "jangregor/phpstan-prophecy": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
         "symfony/var-dumper": "^7.0"

--- a/src/functions.php
+++ b/src/functions.php
@@ -39,8 +39,8 @@ use function is_object;
 use function is_string;
 use function max;
 use function property_exists;
-use function Safe\substr;
 use function strpos;
+use function substr;
 
 use const ARRAY_FILTER_USE_BOTH;
 


### PR DESCRIPTION
- substr() does not return false since PHP 8.0